### PR TITLE
bug fix(公钥生成bytes的bug，导致验签失败)

### DIFF
--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -134,7 +134,7 @@ func (pub *PublicKey) GetUnCompressBytes() []byte {
 
 	if yl > KeyBytes {
 		copy(raw[1+KeyBytes:], yBytes[yl-KeyBytes:])
-	} else if xl < KeyBytes {
+	} else if yl < KeyBytes {
 		copy(raw[1+KeyBytes+(KeyBytes-yl):], yBytes)
 	} else {
 		copy(raw[1+KeyBytes:], yBytes)


### PR DESCRIPTION
计算y的bytes，就应该用Y的长度yl