### PR TITLE
fix bug that the length of C1 bytes is not enough

### DIFF
--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -220,8 +220,8 @@ func kdf(digest hash.Hash, c1x *big.Int, c1y *big.Int, encData []byte) {
 	ct := uint32(0)
 	for off < encDataLen {
 		digest.Reset()
-		digest.Write(c1xBytes)
-		digest.Write(c1yBytes)
+		digest.Write(append(make([]byte, 32-len(c1xBytes)), c1xBytes...))
+		digest.Write(append(make([]byte, 32-len(c1yBytes)), c1yBytes...))
 		ct++
 		binary.BigEndian.PutUint32(buf, ct)
 		digest.Write(buf[:4])
@@ -322,9 +322,9 @@ func Decrypt(priv *PrivateKey, in []byte, cipherTextType Sm2CipherTextType) ([]b
 	kdf(digest, c1x, c1y, c2)
 
 	digest.Reset()
-	digest.Write(c1x.Bytes())
+	digest.Write(append(make([]byte, 32-len(c1x.Bytes())), c1x.Bytes()...))
 	digest.Write(c2)
-	digest.Write(c1y.Bytes())
+	digest.Write(append(make([]byte, 32-len(c1y.Bytes())), c1y.Bytes()...))
 	newC3 := digest.Sum(nil)
 
 	if !bytes.Equal(newC3, c3) {


### PR DESCRIPTION
#### 问题
在对接Java端（使用的BouncyCastle库，version 1.60）时，采用的是Java端通过公钥加密数据，在Golang端使用私钥解密密文，会出现偶发性的解密失败；（Java端自行解密是ok的）

#### 原因
经过排查，跟踪定位发现是解密时使用私钥和C1计算得到的点（记为Cn），输出bytes字节数组后，没有去校验这个bytes字节数组的长度; 而当Cn点较小时，Golang后端通过`big.Int`表示的Cn点的横纵坐标进行输出到bytes字节数组时，其横纵坐标的字节数组长度将不足32位 (见`big.Int.Bytes()`方法)，从而影响接下来对C2部分的解密及C3部分的校验

#### 解决方案
 对横纵坐标输出的bytes字节数组补足32位长度，分别需要在`kdf`中（处理C2部分时）及`Decrypt`中（处理C3部分时）做该处理；（至于`Encrypt`部分还烦请进一步考虑）

同时感谢 [Issues#9](https://github.com/ZZMarquis/gm/issues/9) 中提供的思路及建议做问题排查及解决